### PR TITLE
Remove redundant backend checks

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,10 +41,6 @@ jobs:
         run: timeout 10s poetry run pip --version || rm -rf .venv
       - name: Install Dependencies
         run: just install-backend
-      - name: Black check
-        run: just black-ci
-      - name: Lint with ruff
-        run: just ruff-ci
       - name: mypy check
         run: just mypy-ci
 


### PR DESCRIPTION
Black and ruff checks are handled by pre-commit.ci now so not needed here.