### PR TITLE
Override rounds for testing

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -29,5 +29,5 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     return argon2.verify(plain_password, hashed_password)
 
 
-def get_password_hash(password: str) -> str:
-    return argon2.using(rounds=DEFAULT_ROUNDS).hash(password)
+def get_password_hash(password: str, *, _rounds: int = DEFAULT_ROUNDS) -> str:
+    return argon2.using(rounds=_rounds).hash(password)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -48,7 +48,7 @@ def user_data():
     return {
         "_id": "649a39c599ef045345c94afc",
         "user_name": "immauser",
-        "hashed_password": get_password_hash("test_password"),
+        "hashed_password": get_password_hash("test_password", _rounds=1),
         "goals": [
             {
                 "id": str(uuid4()),
@@ -102,7 +102,9 @@ async def user_no_goals(user_data):
 @pytest.fixture
 async def admin_user():
     return await User(
-        user_name="admin", hashed_password=get_password_hash("test_password"), is_admin=True
+        user_name="admin",
+        hashed_password=get_password_hash("test_password", _rounds=1),
+        is_admin=True,
     ).insert()
 
 


### PR DESCRIPTION
Closes #107

There were issues with session scoping the needed fixtures so instead I overrode the default rounds for hashing in the fixtures for testing. Doing this reduced the run time for the test suite by ~148% (2 minutes 15 seconds down to 20 seconds).