### PR TITLE
Bump ruff and prettier pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
           #     - id: mypy
           #       additional_dependencies: [pydantic]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.281
+    rev: v0.0.282
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
+    rev: v3.0.1
     hooks:
       - id: prettier
         additional_dependencies:


### PR DESCRIPTION
[https://github.com/astral-sh/ruff-pre-commit] updating v0.0.281 -> v0.0.282
[https://github.com/pre-commit/mirrors-prettier] updating v3.0.0 -> v3.0.1